### PR TITLE
Add Plain-Thread parser and GUI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,19 @@ python AUTO_X.py
 Type your entire thread in the text box. You can separate tweets manually using a blank line, or let the app split the text automatically.
 
 Once parsed, you can attach images to each tweet and publish the thread.
+
+## Plain-Thread v1
+
+The app also supports parsing a numeric format for pre-written threads. Paste text following this structure:
+
+```
+1
+
+First tweet text
+
+2
+
+Second tweet text
+```
+
+Each block begins with an index line containing only digits, followed by a blank line and the tweet body. Indices must be consecutive and each body must stay within 280 characters. Use the **Parse Plain-Thread** button to load the tweets automatically.

--- a/plain_thread.py
+++ b/plain_thread.py
@@ -1,0 +1,53 @@
+import re
+from typing import List
+
+MAX_TWEET_LEN = 280
+
+
+def parse_plain_thread(raw: str) -> List[str]:
+    """Parse a Plain-Thread v1 string into a list of tweets.
+
+    Parameters
+    ----------
+    raw : str
+        Entire plain-thread text as pasted by the user.
+
+    Returns
+    -------
+    List[str]
+        List of tweet bodies ready for publishing.
+
+    Raises
+    ------
+    ValueError
+        If the format rules are not met.
+    """
+    # 1. Normalize newlines and trim final whitespace
+    data = raw.replace("\r\n", "\n").strip() + "\n"
+
+    # 2. Find indices with regex anchored to line start
+    pattern = re.compile(r"^([0-9]+)\n\n", re.MULTILINE)
+    positions = [(m.start(), int(m.group(1))) for m in pattern.finditer(data)]
+    if not positions:
+        raise ValueError("No se encontraron índices numéricos.")
+
+    tweets = []
+    for i, (pos, idx) in enumerate(positions):
+        start = pos + len(str(idx)) + 2  # account for '\n\n'
+        end = positions[i + 1][0] if i + 1 < len(positions) else len(data)
+        body = data[start:end].strip()
+        tweets.append((idx, body))
+
+    # 3. Validations
+    expected = list(range(1, len(tweets) + 1))
+    found = [idx for idx, _ in tweets]
+    if found != expected:
+        raise ValueError(f"Índices fuera de orden o faltantes: {found} ≠ {expected}")
+    for idx, body in tweets:
+        if not body:
+            raise ValueError(f"Tweet #{idx} vacío.")
+        if len(body) > MAX_TWEET_LEN:
+            raise ValueError(f"Tweet #{idx} supera {MAX_TWEET_LEN} caracteres.")
+
+    # 4. Return only text bodies
+    return [body for _, body in tweets]

--- a/tests/test_plain_thread.py
+++ b/tests/test_plain_thread.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "plain_thread", Path(__file__).resolve().parents[1] / "plain_thread.py"
+)
+plain_thread = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(plain_thread)
+parse_plain_thread = plain_thread.parse_plain_thread
+MAX_TWEET_LEN = plain_thread.MAX_TWEET_LEN
+
+
+def test_parse_plain_thread_happy():
+    raw = """1
+
+hola
+
+2
+
+adios
+"""
+    assert parse_plain_thread(raw) == ["hola", "adios"]
+
+
+def test_parse_plain_thread_bad_order():
+    raw = """1
+
+hola
+
+3
+
+oops
+"""
+    with pytest.raises(ValueError):
+        parse_plain_thread(raw)
+
+
+def test_parse_plain_thread_too_long():
+    body = "x" * (MAX_TWEET_LEN + 1)
+    raw = f"1\n\n{body}\n"
+    with pytest.raises(ValueError):
+        parse_plain_thread(raw)


### PR DESCRIPTION
## Summary
- implement `parse_plain_thread` utility to parse indexed text blocks
- add GUI button and handlers for the new parsing mode
- refactor tweet preview rendering to reuse code
- document the Plain-Thread format in the README
- add unit tests for the parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a06da3df8832abc76625611594f10