### PR TITLE
Add guide for writing thread text

### DIFF
--- a/WRITING_GUIDE.md
+++ b/WRITING_GUIDE.md
@@ -1,0 +1,33 @@
+# Guía para construir textos separables en tweets
+
+Esta guía explica cómo redactar tu hilo de forma que la aplicación **X Thread Composer** pueda dividirlo correctamente en tweets individuales.
+
+## 1. Redacción básica
+
+- Escribe todo tu hilo en el cuadro de texto principal de la aplicación.
+- Si quieres controlar manualmente dónde empieza cada tweet, separa los párrafos con una línea en blanco. La app tomará cada bloque separado por dos saltos de línea como un tweet independiente.
+- Si no utilizas líneas en blanco, la app dividirá el texto automáticamente respetando los límites de 280 caracteres y procurando no cortar palabras a la mitad.
+
+## 2. Formato Plain-Thread (opcional)
+
+La app también soporta un formato numérico para hilos ya escritos. Cada tweet se indica con un número seguido de una línea en blanco y el texto del tweet. Los índices deben ser consecutivos.
+
+```
+1
+
+Texto del primer tweet
+
+2
+
+Texto del segundo tweet
+```
+
+Este método resulta útil si preparas el hilo en otro editor y quieres importar las divisiones exactas.
+
+## 3. Consejos adicionales
+
+- Mantén cada tweet por debajo de 280 caracteres.
+- Evita palabras extremadamente largas que puedan dificultar la separación automática.
+- Puedes agregar imágenes a cada tweet una vez que el texto haya sido procesado.
+
+Siguiendo estas pautas tu texto quedará listo para publicarse como hilo en X sin problemas.


### PR DESCRIPTION
## Summary
- add a Spanish guide with recommendations to write thread text so the app can split it into tweets

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0b2a9614832a8f96fdf31f73b39d